### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The claude-code-mcp project is an MCP server for Claude Code.
 It calls the locally installed Claude Code command and provides the following tools: `explain_code`, `review_code`, `fix_code`, `edit_code`, `test_code`, `simulate_command`, and `your_own_query`. The server is implemented using Node.js and the MCP SDK, receiving JSON format requests from clients via stdio. Internally, it adopts Base64 encoding to smoothly process special characters (newlines, quotation marks, etc.) in natural language text, resulting in improved stability and flexibility. Its main roles are receiving requests, encoding input, generating and executing commands, and returning execution results in JSON format.
 This project has been confirmed to work in Claude Code CLI environments (Ubuntu/WSL2, etc.).
 
+<a href="https://glama.ai/mcp/servers/@KunihiroS/claude-code-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@KunihiroS/claude-code-mcp/badge" alt="claude-code-mcp MCP server" />
+</a>
+
 💡
 MCP Host with less capable LLM, can tame and make use of Claude power💪!
 With claude-code-mcp, you can also call Claude Code from Claude Desktop!! 😇😜😎 (unconfirmed)


### PR DESCRIPTION
This PR adds a badge for the [claude-code-mcp](https://glama.ai/mcp/servers/@KunihiroS/claude-code-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@KunihiroS/claude-code-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@KunihiroS/claude-code-mcp/badge" alt="claude-code-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.